### PR TITLE
quickly skip team if we don't have permission to change it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ASANASYNC_GOOGLE_PEM_SUBJECT=domain_admin@domain.org
 ASANASYNC_MYSQL_CONFIG=dbuser:password@/db_name
 ASANASYNC_ASANA_PERSONAL_ACCESS_TOKEN=0/9acc...
 ASANASYNC_GOOGLE_PEM_VALUE=Bag Attributes friendlyName: privatekey...`
+for MYSQL_CONFIG, description of format is [here](https://github.com/go-sql-driver/mysql#dsn-data-source-name)
 
 ## Future improvements:
 Check descriptions for workspaces and projects and add any aliases in there to permission for said workspace or project (but no need to add entries for folks already in a higher level)


### PR DESCRIPTION
this makes it such that if the first attempt to add a user to a team yields a permissions error, we don't try in vain to add more... skip to the next team.